### PR TITLE
Round down (floor) the tooltip value

### DIFF
--- a/openspending/static/find-ui/dist/app/js/common/utils.js
+++ b/openspending/static/find-ui/dist/app/js/common/utils.js
@@ -884,7 +884,7 @@
                 tooltip: {
                     formatter: function () {
                         var number = this.point.y
-                        return indicatorsMeta[0][0].label+'<br/>'+this.key+': <b>'+this.point.y+'</b>'
+                        return indicatorsMeta[0][0].label+'<br/>'+this.key+': <b>'+Math.floor(this.point.y)+'</b>'
                     }
                 },
                 series: seriesArray


### PR DESCRIPTION
--Tooltip had remainder for some values. Round down all point.y values
Related to #209 
